### PR TITLE
Fix *bound configuration. It seems to be hard coded in two places

### DIFF
--- a/simulator-core/src/main/java/com/tacitknowledge/simulator/configuration/loaders/ConversationLoader.java
+++ b/simulator-core/src/main/java/com/tacitknowledge/simulator/configuration/loaders/ConversationLoader.java
@@ -170,7 +170,7 @@ public class ConversationLoader
         {
             Properties properties = loadConversationProperties(is);
 
-            return getConversationTransport(Configurable.BOUND_IN, properties);
+            return getConversationTransport(bound, properties);
         }
         finally
         {
@@ -190,7 +190,7 @@ public class ConversationLoader
         {
             Properties properties = loadConversationProperties(is);
 
-            return getConversationAdapter(Configurable.BOUND_IN, properties);
+            return getConversationAdapter(bound, properties);
         }
         finally
         {


### PR DESCRIPTION
Can anyone comment if hardcoded values below are deliberate or this is a bug?
